### PR TITLE
Disable anything but PHP Error with Debug Mode off

### DIFF
--- a/lib-core.php
+++ b/lib-core.php
@@ -16,7 +16,10 @@
 */
 @(require_once('config.php'));
 include('version.php');
-$debug = 0; // Set to 1 in order to enable debug mode (shows sensitive database info), use for troubleshooting
+$debug = false; // Set to 1 in order to enable debug mode (shows sensitive database info), use for troubleshooting
+if ( $debug === FALSE ) {
+    error_reporting(E_ERROR);
+}
 $footer = "&copy; Copyright 2014 $wsn. Powered by <a href='http://github.com/cydrobolt/polr'>Polr</a> ver $version build $reldate";
 $hidefooter = true; // Let's hide this for now
 //connect to mysql with $mysqli variable

--- a/lib-core.php
+++ b/lib-core.php
@@ -16,9 +16,13 @@
 */
 @(require_once('config.php'));
 include('version.php');
-$debug = false; // Set to 1 in order to enable debug mode (shows sensitive database info), use for troubleshooting
+// Set to TRUE to enable debug mode (shows sensitive database info), use for troubleshooting only!
+// Also enables PHP error reporting level E_ALL
+$debug = FALSE;
 if ( $debug === FALSE ) {
-    error_reporting(E_ERROR);
+    error_reporting( 0 );
+} else {
+    error_reporting( E_ALL );
 }
 $footer = "&copy; Copyright 2014 $wsn. Powered by <a href='http://github.com/cydrobolt/polr'>Polr</a> ver $version build $reldate";
 $hidefooter = true; // Let's hide this for now


### PR DESCRIPTION
Disable all PHP Warning/Notice/Whatever Outputs except Errors when `$debug` mode is off.

People who don't want polrs internal outputs probably don't want php debug output either.

Admittedly, this probably isn't an issue on 99% of hosts (disabled php debug by default), but for consistency's sake, it doesn't hurt.