### PR TITLE
SELinux installation context settings #150

### DIFF
--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -36,6 +36,9 @@ $ chmod -R 755 polr
 $ chown -R www-data polr
 # run only if on Fedora-based systems
 $ chown -R apache polr
+
+# run only if on recent Fedora, or other system, with SELinux enforcing
+$ chcon -R -t httpd_sys_rw_content_t polr/storage polr/.env
 ```
 
 ## Installing using `composer`


### PR DESCRIPTION
A simple additional note for the installation to make just the required files writeable in the webserver SELinux context (see issue #150 )