### PR TITLE
Adds a missing semi-colon to the nginx configuration

### DIFF
--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -131,7 +131,7 @@ server {
             fastcgi_pass    php;
             fastcgi_index   index.php;
             fastcgi_param   SCRIPT_FILENAME $document_root$fastcgi_script_name;
-            fastcgi_param   HTTP_HOST       $server_name
+            fastcgi_param   HTTP_HOST       $server_name;
     }
 }
 


### PR DESCRIPTION
Without it nginx fails to restart

```bash
nginx: [emerg] unexpected "}" in /etc/nginx/sites-enabled/polr.conf:30
nginx: configuration file /etc/nginx/nginx.conf test failed
```