### PR TITLE
[CryptoHelper.php] use random_bytes() function

### DIFF
--- a/app/Helpers/CryptoHelper.php
+++ b/app/Helpers/CryptoHelper.php
@@ -3,7 +3,7 @@ namespace App\Helpers;
 
 class CryptoHelper {
     public static function generateRandomHex($rand_bytes_num) {
-        $rand_bytes = openssl_random_pseudo_bytes($rand_bytes_num, $crypt_secure);
+        $rand_bytes = random_bytes($rand_bytes_num);
         return bin2hex($rand_bytes);
     }
 }


### PR DESCRIPTION
`random_bytes` function would provide better random values (and maybe performance) even in PHP < 7.0 since `random_compat` library is a dependency.