### PR TITLE
Patch XSS vulnerability in DataTables

### DIFF
--- a/app/Http/Controllers/AdminPaginationController.php
+++ b/app/Http/Controllers/AdminPaginationController.php
@@ -22,7 +22,7 @@ class AdminPaginationController extends Controller {
             ->addColumn('api_action', function ($user) {
                 // Add "API Info" action button
                 return '<a class="activate-api-modal btn btn-sm btn-info"
-                    ng-click="openAPIModal($event, \'' . $user->username . '\', \'' . $user->api_key . '\', \'' . $user->api_active . '\', \'' . $user->api_quota . '\', \'' . $user->id . '\')">
+                    ng-click="openAPIModal($event, \'' . e($user->username) . '\', \'' . $user->api_key . '\', \'' . $user->api_active . '\', \'' . e($user->api_quota) . '\', \'' . $user->id . '\')">
                     API info
                 </a>';
             })
@@ -49,8 +49,8 @@ class AdminPaginationController extends Controller {
                 // FIXME <select> field does not use Angular bindings
                 // because of an issue affecting fields with duplicate names.
 
-                $select_role = '<select ng-init="changeUserRole.u'.$user->id.' = \''.$user->role.'\'"
-                    ng-model="changeUserRole.u'.$user->id.'" ng-change="changeUserRole(changeUserRole.u'.$user->id.', '.$user->id.')"
+                $select_role = '<select ng-init="changeUserRole.u' . $user->id . ' = \'' . e($user->role) . '\'"
+                    ng-model="changeUserRole.u' . $user->id . '" ng-change="changeUserRole(changeUserRole.u' . $user->id . ', '.$user->id.')"
                     class="form-control"';
 
                 if (session('username') == $user->username) {
@@ -61,13 +61,13 @@ class AdminPaginationController extends Controller {
 
                 foreach (UserHelper::USER_ROLES as $role_text => $role_val) {
                     // Iterate over each available role and output option
-                    $select_role .= '<option value="' . $role_val . '"';
+                    $select_role .= '<option value="' . e($role_val) . '"';
 
                     if ($user->role == $role_val) {
                         $select_role .= ' selected';
                     }
 
-                    $select_role .= '>' . $role_text . '</option>';
+                    $select_role .= '>' . e($role_text) . '</option>';
                 }
 
                 $select_role .= '</select>';
@@ -83,6 +83,7 @@ class AdminPaginationController extends Controller {
                     Delete
                 </a>';
             })
+            ->escapeColumns(['username', 'email'])
             ->make(true);
     }
 
@@ -101,17 +102,18 @@ class AdminPaginationController extends Controller {
                     $btn_text = 'Enable';
                 }
 
-                return '<a ng-click="toggleLink($event, \'' . $link->short_url . '\')" class="btn btn-sm ' . $btn_class . '">
+                return '<a ng-click="toggleLink($event, \'' . e($link->short_url) . '\')" class="btn btn-sm ' . $btn_class . '">
                     ' . $btn_text . '
                 </a>';
             })
             ->addColumn('delete', function ($link) {
                 // Add "Delete" action button
-                return '<a ng-click="deleteLink($event, \'' . $link->short_url  . '\')"
+                return '<a ng-click="deleteLink($event, \'' . e($link->short_url)  . '\')"
                     class="btn btn-sm btn-warning delete-link">
                     Delete
                 </a>';
             })
+            ->escapeColumns(['short_url', 'long_url', 'creator'])
             ->make(true);
     }
 
@@ -123,6 +125,7 @@ class AdminPaginationController extends Controller {
             ->select(['short_url', 'long_url', 'clicks', 'created_at']);
 
         return Datatables::of($user_links)
+            ->escapeColumns()
             ->make(true);
     }
 }

--- a/app/Http/Controllers/Api/ApiLinkController.php
+++ b/app/Http/Controllers/Api/ApiLinkController.php
@@ -2,7 +2,6 @@
 namespace App\Http\Controllers\Api;
 use Illuminate\Http\Request;
 
-
 use App\Factories\LinkFactory;
 use App\Helpers\LinkHelper;
 
@@ -12,9 +11,13 @@ class ApiLinkController extends ApiController {
         $user = self::getApiUserInfo($request);
 
         // Validate parameters
-        $validator = \Validator::make($request->all(), [
+        // Encode spaces as %20 to avoid validator conflicts
+        $validator = \Validator::make(array_merge([
+            'url' => str_replace(' ', '%20', $request->input('url'))
+        ], $request->except('url')), [
             'url' => 'required|url'
         ]);
+
         if ($validator->fails()) {
             return abort(400, 'Parameters invalid or missing.');
         }

--- a/app/Http/Controllers/LinkController.php
+++ b/app/Http/Controllers/LinkController.php
@@ -26,7 +26,8 @@ class LinkController extends Controller {
 
         // Validate URL form data
         $this->validate($request, [
-            'link-url' => 'required|url'
+            'link-url' => 'required|url',
+            'custom-ending' => 'alpha_dash'
         ]);
 
         $long_url = $request->input('link-url');

--- a/app/Http/Controllers/LinkController.php
+++ b/app/Http/Controllers/LinkController.php
@@ -24,14 +24,15 @@ class LinkController extends Controller {
             return redirect(route('index'))->with('error', 'You must be logged in to shorten links.');
         }
 
-        $this->request = $request;
+        // Validate URL form data
+        $this->validate($request, [
+            'link-url' => 'required|url'
+        ]);
 
         $long_url = $request->input('link-url');
         $custom_ending = $request->input('custom-ending');
         $is_secret = ($request->input('options') == "s" ? true : false);
-
         $creator = session('username');
-
         $link_ip = $request->ip();
 
         try {

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -57,14 +57,16 @@ class UserController extends Controller {
             return redirect(route('index'))->with('error', 'Sorry, but registration is disabled.');
         }
 
+        // Validate signup form data
+        $this->validate($request, [
+            'username' => 'required|alpha_dash',
+            'password' => 'required',
+            'email' => 'required|email'
+        ]);
+
         $username = $request->input('username');
         $password = $request->input('password');
         $email = $request->input('email');
-
-        if (!self::checkRequiredArgs([$username, $password, $email])) {
-            // missing a required argument
-            return redirect(route('signup'))->with('error', 'Please fill in all required fields.');
-        }
 
         $ip = $request->ip();
 

--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Middleware;
+use Laravel\Lumen\Http\Middleware\VerifyCsrfToken as BaseVerifier;
+
+class VerifyCsrfToken extends BaseVerifier
+{
+    /**
+     * Exclude API routes from CSRF protection.
+     *
+     * @var array
+     */
+    public function handle($request, \Closure $next) {
+        if ($request->is('api/v*/action/*')) {
+            // Exclude public API from CSRF protection
+            // but do not exclude private API endpoints
+            return $next($request);
+        }
+
+        return parent::handle($request, $next);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -59,8 +59,8 @@ $app->middleware([
     Illuminate\Cookie\Middleware\EncryptCookies::class,
     // Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
     Illuminate\Session\Middleware\StartSession::class,
-    // Illuminate\View\Middleware\ShareErrorsFromSession::class,
-    Laravel\Lumen\Http\Middleware\VerifyCsrfToken::class,
+    Illuminate\View\Middleware\ShareErrorsFromSession::class,
+    App\Http\Middleware\VerifyCsrfToken::class
 ]);
 
 // $app->routeMiddleware([

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -102,6 +102,8 @@ return [
     |
     */
 
-    'attributes' => [],
+    'attributes' => [
+        'link-url' => 'link URL'
+    ],
 
 ];

--- a/resources/views/layouts/base.blade.php
+++ b/resources/views/layouts/base.blade.php
@@ -70,6 +70,13 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     @if (Session::has('success'))
         toastr["success"](`{{session('success')}}`, "Success")
     @endif
+
+    @if (count($errors) > 0)
+        // Handle Lumen validation errors
+        @foreach ($errors->all() as $error)
+            toastr["error"](`{{$error}}`, "Error")
+        @endforeach
+    @endif
     </script>
 
     @yield('js')


### PR DESCRIPTION
This PR patches a critical XSS vulnerability that permits arbitrary code execution through DataTables.

-----
Cross-site scripting (XSS) vulnerability in Polr 2.0.0 which allows remote attackers to execute arbitrary JavaScript code on admin panels on Polr instances which have (1) public account registration or (2) public URL shortening enabled. CVE identifier pending.

Versions Affected:  2.0.0 (74acbecbd1ccf3b583319f167f880585e3fce78d or newer)
Fixed Versions:      2.1.0 or newer

## Impact

DataTables columns were not being escaped, providing an XSS attack vector for users. This only affects Polr instances running 2.0.0 (74acbecbd1ccf3b583319f167f880585e3fce78d or newer). Users running a release version of 2.0.0 (4511499bb5606fc7d18375b493c86b61a7dfbdeb) are not affected, but users using the `master` branch of the repository with ref 74acbecbd1ccf3b583319f167f880585e3fce78d or newer are affected.

Instances with the following settings are affected
 - `SETTING_SHORTEN_PERMISSION=false`
 - `POLR_ALLOW_ACCT_CREATION=true`

## Releases

The 2.1.0 release is available at https://github.com/cydrobolt/polr

## Upgrade Process

Upgrade to Polr version of at least 2.1.0 or pull the latest `master` branch

## Workarounds

Set `POLR_ALLOW_ACCT_CREATION=false` and `SETTING_SHORTEN_PERMISSION=true`. 
If an attacker has already exploited this vulnerability on your instance, you must upgrade to be protected.