### PR TITLE
Trim long URLs on admin dash.

### DIFF
--- a/app/Http/Controllers/AdminPaginationController.php
+++ b/app/Http/Controllers/AdminPaginationController.php
@@ -113,7 +113,8 @@ class AdminPaginationController extends Controller {
                     Delete
                 </a>';
             })
-            ->escapeColumns(['short_url', 'long_url', 'creator'])
+            ->editColumn('long_url', '<a target="_blank" title="{{ $long_url }}" href="{{ $long_url }}">{{ str_limit($long_url, 50)}}</a>')
+            ->escapeColumns(['short_url', 'creator'])
             ->make(true);
     }
 
@@ -125,7 +126,8 @@ class AdminPaginationController extends Controller {
             ->select(['short_url', 'long_url', 'clicks', 'created_at']);
 
         return Datatables::of($user_links)
-            ->escapeColumns()
+            ->editColumn('long_url', '<a target="_blank" title="{{ $long_url }}" href="{{ $long_url }}">{{ str_limit($long_url, 50)}}</a>')
+            ->escapeColumns(['short_url'])
             ->make(true);
     }
 }

--- a/public/js/AdminCtrl.js
+++ b/public/js/AdminCtrl.js
@@ -45,8 +45,8 @@ polr.controller('AdminCtrl', function($scope, $compile) {
                 "ajax": BASE_API_PATH + 'admin/get_admin_links',
 
                 "columns": [
-                    {className: 'wrap-text', data: 'short_url', name: 'short_url'},
-                    {className: 'wrap-text', data: 'long_url', name: 'long_url'},
+                    {data: 'short_url', name: 'short_url'},
+                    {data: 'long_url', name: 'long_url', width: '30%'},
                     {data: 'clicks', name: 'clicks'},
                     {data: 'created_at', name: 'created_at'},
                     {data: 'creator', name: 'creator'},
@@ -62,8 +62,8 @@ polr.controller('AdminCtrl', function($scope, $compile) {
             "ajax": BASE_API_PATH + 'admin/get_user_links',
 
             "columns": [
-                {className: 'wrap-text', data: 'short_url', name: 'short_url'},
-                {className: 'wrap-text', data: 'long_url', name: 'long_url'},
+                {data: 'short_url', name: 'short_url'},
+                {data: 'long_url', name: 'long_url', width: '50%'},
                 {data: 'clicks', name: 'clicks'},
                 {data: 'created_at', name: 'created_at'}
             ]

--- a/public/js/AdminCtrl.js
+++ b/public/js/AdminCtrl.js
@@ -45,8 +45,8 @@ polr.controller('AdminCtrl', function($scope, $compile) {
                 "ajax": BASE_API_PATH + 'admin/get_admin_links',
 
                 "columns": [
-                    {data: 'short_url', name: 'short_url'},
-                    {data: 'long_url', name: 'long_url'},
+                    {className: 'wrap-text', data: 'short_url', name: 'short_url'},
+                    {className: 'wrap-text', data: 'long_url', name: 'long_url'},
                     {data: 'clicks', name: 'clicks'},
                     {data: 'created_at', name: 'created_at'},
                     {data: 'creator', name: 'creator'},
@@ -62,8 +62,8 @@ polr.controller('AdminCtrl', function($scope, $compile) {
             "ajax": BASE_API_PATH + 'admin/get_user_links',
 
             "columns": [
-                {data: 'short_url', name: 'short_url'},
-                {data: 'long_url', name: 'long_url'},
+                {className: 'wrap-text', data: 'short_url', name: 'short_url'},
+                {className: 'wrap-text', data: 'long_url', name: 'long_url'},
                 {data: 'clicks', name: 'clicks'},
                 {data: 'created_at', name: 'created_at'}
             ]

--- a/public/js/AdminCtrl.js
+++ b/public/js/AdminCtrl.js
@@ -46,7 +46,7 @@ polr.controller('AdminCtrl', function($scope, $compile) {
 
                 "columns": [
                     {data: 'short_url', name: 'short_url'},
-                    {data: 'long_url', name: 'long_url', width: '30%'},
+                    {data: 'long_url', name: 'long_url'},
                     {data: 'clicks', name: 'clicks'},
                     {data: 'created_at', name: 'created_at'},
                     {data: 'creator', name: 'creator'},
@@ -63,7 +63,7 @@ polr.controller('AdminCtrl', function($scope, $compile) {
 
             "columns": [
                 {data: 'short_url', name: 'short_url'},
-                {data: 'long_url', name: 'long_url', width: '50%'},
+                {data: 'long_url', name: 'long_url'},
                 {data: 'clicks', name: 'clicks'},
                 {data: 'created_at', name: 'created_at'}
             ]


### PR DESCRIPTION
As per #258, implemented URL trimming. URL is shown on hover, and when clicked is opened in a new tab.
I also made the URL columns wider, since they were unnecessarily small.

Screenshots:
http://puu.sh/sUwWV/1577eed220.png
http://puu.sh/sUwXw/0b6fbcd696.png  