### PR TITLE
Add index to nginx config

### DIFF
--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -122,6 +122,7 @@ server {
     location / {
             try_files $uri $uri/ /index.php$is_args$args;
             # rewrite ^/([a-zA-Z0-9]+)/?$ /index.php?$1;
+            index index.php;
     }
 
     location ~ \.php$ {


### PR DESCRIPTION
No index set for example nginx config - without this, user will get
403 Forbidden error on browsing to site.