### PR TITLE
Fixed wrong status code being sent by 404 error

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -47,8 +47,11 @@ class Handler extends ExceptionHandler {
                     // Redirect 404s to SETTING_INDEX_REDIRECT
                     return redirect()->to(env('SETTING_INDEX_REDIRECT'));
                 }
-                // Otherwise, show a nice error page
-                return view('errors.404');
+                // Otherwise, show a nice error page with 404 error code
+                $status_code = $e->getStatusCode();
+                $status_message = $e->getMessage();
+                return response(view('errors.404', ['status_code' => $status_code, 'status_message' => $status_message]), $status_code);
+
             }
             if ($e instanceof HttpException) {
                 $status_code = $e->getStatusCode();


### PR DESCRIPTION
When looking up shortened URLs which don't exist there's no 404 status code returned, just the error page with a 200 status code. This commit fixes this error.

Fix for michaelachmann/LnkShortener/issues/13
