### PR TITLE
Updated deprecated error methods in LinkController

### DIFF
--- a/app/Http/Controllers/LinkController.php
+++ b/app/Http/Controllers/LinkController.php
@@ -19,6 +19,16 @@ class LinkController extends Controller {
     private function renderError($message) {
         return redirect(route('index'))->with('error', $message);
     }
+    
+    private function linkNotFound() {
+        if (env('SETTING_REDIRECT_404')) {
+            return redirect()->to(env('SETTING_INDEX_REDIRECT'));
+        }
+
+        return response(view('error', [
+            'message' => 'Sorry, but this link does not exist.'
+        ]), 404);
+    }
 
     public function performShorten(Request $request) {
         if (env('SETTING_SHORTEN_PERMISSION') && !self::isLoggedIn()) {
@@ -54,13 +64,7 @@ class LinkController extends Controller {
         // Return an error if the link does not exist
         // or return a 404 if SETTING_REDIRECT_404 is set to true
         if ($link == null) {
-            if (env('SETTING_REDIRECT_404')) {
-                return redirect()->to(env('SETTING_INDEX_REDIRECT'));
-            }
-            
-            return response(view('error', [
-                'message' => 'Sorry, but this link does not exist.'
-            ]), 404);
+            return self::linkNotFound();
         }
 
         // Return an error if the link has been disabled
@@ -81,24 +85,12 @@ class LinkController extends Controller {
         	if (!$secret_key) {
         		// if we do not receieve a secret key
         		// when we are expecting one, return a 404 to keep the link secret
-                if (env('SETTING_REDIRECT_404')) {
-                    return redirect()->to(env('SETTING_INDEX_REDIRECT'));
-                }
-                
-                return response(view('error', [
-                    'message' => 'Sorry, but this link does not exist.'
-                ]), 404);
+                return self::linkNotFound();
         	}
         	else {
         		if ($link_secret_key != $secret_key) {
         			// a secret key is provided, but it is incorrect, return a 404 to keep the link secret
-                    if (env('SETTING_REDIRECT_404')) {
-                        return redirect()->to(env('SETTING_INDEX_REDIRECT'));
-                    }
-                    
-                    return response(view('error', [
-                        'message' => 'Sorry, but this link does not exist.'
-                    ]), 404);
+                    return self::linkNotFound();
         		}
         	}
         }

--- a/app/Http/Controllers/LinkController.php
+++ b/app/Http/Controllers/LinkController.php
@@ -51,16 +51,23 @@ class LinkController extends Controller {
         $link = Link::where('short_url', $short_url)
             ->first();
 
-        // Return 404 if link not found
+        // Return an error if the link does not exist
+        // or return a 404 if SETTING_REDIRECT_404 is set to true
         if ($link == null) {
-        	return abort(404);
+            if (env('SETTING_REDIRECT_404')) {
+                return response(view("errors.404"), 404);
+            }
+            
+            return view('error', [
+                'message' => 'Sorry, but this link does not exist.'
+            ]);
         }
 
         // Return an error if the link has been disabled
         // or return a 404 if SETTING_REDIRECT_404 is set to true
         if ($link->is_disabled == 1) {
             if (env('SETTING_REDIRECT_404')) {
-                return abort(404);
+                return response(view("errors.404"), 404);
             }
 
             return view('error', [
@@ -74,12 +81,16 @@ class LinkController extends Controller {
         	if (!$secret_key) {
         		// if we do not receieve a secret key
         		// when we are expecting one, return a 403
-        		return abort(403);
+                return view('error', [
+                    'message' => 'Sorry, but this link needs a secret key.'
+                ]);
         	}
         	else {
         		if ($link_secret_key != $secret_key) {
         			// a secret key is provided, but it is incorrect
-        			return abort(403);
+                    return view('error', [
+                        'message' => 'Sorry, but the secret key provided is incorrect.'
+                    ]);
         		}
         	}
         }

--- a/app/Http/Controllers/LinkController.php
+++ b/app/Http/Controllers/LinkController.php
@@ -81,6 +81,10 @@ class LinkController extends Controller {
         	if (!$secret_key) {
         		// if we do not receieve a secret key
         		// when we are expecting one, return a 404 to keep the link secret
+                if (env('SETTING_REDIRECT_404')) {
+                    return redirect()->to(env('SETTING_INDEX_REDIRECT'));
+                }
+                
                 return response(view('error', [
                     'message' => 'Sorry, but this link does not exist.'
                 ]), 404);
@@ -88,6 +92,10 @@ class LinkController extends Controller {
         	else {
         		if ($link_secret_key != $secret_key) {
         			// a secret key is provided, but it is incorrect, return a 404 to keep the link secret
+                    if (env('SETTING_REDIRECT_404')) {
+                        return redirect()->to(env('SETTING_INDEX_REDIRECT'));
+                    }
+                    
                     return response(view('error', [
                         'message' => 'Sorry, but this link does not exist.'
                     ]), 404);

--- a/app/Http/Controllers/LinkController.php
+++ b/app/Http/Controllers/LinkController.php
@@ -75,22 +75,22 @@ class LinkController extends Controller {
             ]), 404);
         }
 
-        // Return a 403 if the secret key is incorrect
+        // Return a 404 if the secret key is incorrect
         $link_secret_key = $link->secret_key;
         if ($link_secret_key) {
         	if (!$secret_key) {
         		// if we do not receieve a secret key
-        		// when we are expecting one, return a 403
-                return view('error', [
-                    'message' => 'Sorry, but this link needs a secret key.'
-                ]);
+        		// when we are expecting one, return a 404 to keep the link secret
+                return response(view('error', [
+                    'message' => 'Sorry, but this link does not exist.'
+                ]), 404);
         	}
         	else {
         		if ($link_secret_key != $secret_key) {
-        			// a secret key is provided, but it is incorrect
-                    return view('error', [
-                        'message' => 'Sorry, but the secret key provided is incorrect.'
-                    ]);
+        			// a secret key is provided, but it is incorrect, return a 404 to keep the link secret
+                    return response(view('error', [
+                        'message' => 'Sorry, but this link does not exist.'
+                    ]), 404);
         		}
         	}
         }

--- a/app/Http/Controllers/LinkController.php
+++ b/app/Http/Controllers/LinkController.php
@@ -58,9 +58,9 @@ class LinkController extends Controller {
                 return response(view("errors.404"), 404);
             }
             
-            return view('error', [
+            return response(view('error', [
                 'message' => 'Sorry, but this link does not exist.'
-            ]);
+            ]), 404);
         }
 
         // Return an error if the link has been disabled
@@ -70,9 +70,9 @@ class LinkController extends Controller {
                 return response(view("errors.404"), 404);
             }
 
-            return view('error', [
+            return response(view('error', [
                 'message' => 'Sorry, but this link has been disabled by an administrator.'
-            ]);
+            ]), 404);
         }
 
         // Return a 403 if the secret key is incorrect

--- a/app/Http/Controllers/LinkController.php
+++ b/app/Http/Controllers/LinkController.php
@@ -55,7 +55,7 @@ class LinkController extends Controller {
         // or return a 404 if SETTING_REDIRECT_404 is set to true
         if ($link == null) {
             if (env('SETTING_REDIRECT_404')) {
-                return response(view("errors.404"), 404);
+                return redirect()->to(env('SETTING_INDEX_REDIRECT'));
             }
             
             return response(view('error', [
@@ -67,7 +67,7 @@ class LinkController extends Controller {
         // or return a 404 if SETTING_REDIRECT_404 is set to true
         if ($link->is_disabled == 1) {
             if (env('SETTING_REDIRECT_404')) {
-                return response(view("errors.404"), 404);
+                return redirect()->to(env('SETTING_INDEX_REDIRECT'));
             }
 
             return response(view('error', [


### PR DESCRIPTION
Existing error methods were deprecated in Laravel; this led to unhandled exceptions. This brings them in line with Laravel v5.x

Fixes #344