### PR TITLE
Fix for link stats not working when using PostgreSQL as DB.

### DIFF
--- a/app/Helpers/StatsHelper.php
+++ b/app/Helpers/StatsHelper.php
@@ -43,7 +43,7 @@ class StatsHelper {
             ->where('created_at', '<=', $this->right_bound_parsed);
     }
 
-    public function getDayStats() {
+    public function getDayStatsmySQL() {
         // Return stats by day from the last 30 days
         // date => x
         // clicks => y
@@ -52,6 +52,16 @@ class StatsHelper {
             ->groupBy(DB::raw("DATE_FORMAT(created_at, '%Y-%m-%d')"))
             ->orderBy('x', 'asc')
             ->get();
+
+        return $stats;
+    }
+
+    public function getDayStatspgSQL() {
+      $stats = $this->getBaseRows()
+          ->select(DB::raw("to_char(created_at, 'yyyy-mm-dd') AS x, count(*) AS y"))
+          ->groupBy(DB::raw("to_char(created_at, 'yyyy-mm-dd')"))
+          ->orderBy('x', 'asc')
+          ->get();
 
         return $stats;
     }

--- a/app/Http/Controllers/StatsController.php
+++ b/app/Http/Controllers/StatsController.php
@@ -69,7 +69,15 @@ class StatsController extends Controller {
             }
         }
 
-        $day_stats = $stats->getDayStats();
+        $connection = config('database.default');
+        $driver = config("database.connections.{$connection}.driver");
+
+        if ($driver == "mysql") {
+          $day_stats = $stats->getDayStatsmySQL();
+        }
+        if ($driver == "pgsql") {
+          $day_stats = $stats->getDayStatspgSQL();
+        }
         $country_stats = $stats->getCountryStats();
         $referer_stats = $stats->getRefererStats();
 


### PR DESCRIPTION
PostgreSQL doesn't have DATE_FORMAT, instead it uses to_char, so I made another function on StatsHelper and made StatsController chose the appropriate one based on the driver in use.