### PR TITLE
#348 Disallow creation of restricted URLs

### DIFF
--- a/app/Helpers/LinkHelper.php
+++ b/app/Helpers/LinkHelper.php
@@ -4,6 +4,11 @@ use App\Models\Link;
 use App\Helpers\BaseHelper;
 
 class LinkHelper {
+    const RESTRICTED_SLUGS = [
+        'logout', 'login', 'lost_password', 'signup', 'activate',
+        'admin', 'setup', 'shorten', 'about-polr'
+    ];
+
     static public function checkIfAlreadyShortened($long_link) {
         /**
          * Provided a long link (string),
@@ -86,7 +91,9 @@ class LinkHelper {
 
     static public function validateEnding($link_ending) {
         $is_valid_ending = preg_match('/^[a-zA-Z0-9-_]+$/', $link_ending);
-        return $is_valid_ending;
+        $is_not_restricted = ! in_array($link_ending, self::RESTRICTED_SLUGS);
+
+        return $is_valid_ending && $is_not_restricted;
     }
 
     static public function findPseudoRandomEnding() {

--- a/app/Http/Controllers/LinkController.php
+++ b/app/Http/Controllers/LinkController.php
@@ -28,7 +28,10 @@ class LinkController extends Controller {
         // Validate URL form data
         $this->validate($request, [
             'link-url' => 'required|url',
-            'custom-ending' => 'alpha_dash'
+            'custom-ending' => [
+                'alpha_dash',
+                'not_in:' . implode(',', LinkHelper::RESTRICTED_SLUGS)
+            ]
         ]);
 
         $long_url = $request->input('link-url');


### PR DESCRIPTION
Currently you are able to create a custom link with a route that already exists. While the actual routes take precedence over short urls, we should block creation of them. 