### PR TITLE
Allow click count increment via API

### DIFF
--- a/app/Http/Controllers/Api/ApiLinkController.php
+++ b/app/Http/Controllers/Api/ApiLinkController.php
@@ -66,6 +66,11 @@ class ApiLinkController extends ApiController {
         }
 
         if ($link) {
+            if ($request->has('increment_clicks')) {
+                $link->clicks++;
+                $link->save();
+            }
+
             return self::encodeResponse([
                 'long_url' => $link['long_url'],
                 'created_at' => $link['created_at'],

--- a/docs/developer-guide/api.md
+++ b/docs/developer-guide/api.md
@@ -95,6 +95,7 @@ Arguments:
 
  - `url_ending`: the link ending for the URL to look up. (e.g `5ga`)
  - `url_key` (optional): optional URL ending key for lookups against secret URLs
+ - `increment_clicks` (optional): if set, the click counter on the link will be incremented
 
 Remember that the `url` argument must be URL encoded.
 
@@ -104,7 +105,20 @@ Response:
 ```
 {
     "action": "lookup",
-    "result": "https://google.com"
+    "result": {
+        "long_url": "http://test.com",
+        "created_at": {
+            "date": "2017-10-28 02:21:11.000000",
+            "timezone_type": 3,
+            "timezone": "UTC"
+        },
+        "clicks": 4,
+        "updated_at": {
+            "date": "2017-10-28 03:17:25.000000",
+            "timezone_type": 3,
+            "timezone": "UTC"
+        }
+    }
 }
 ```
 


### PR DESCRIPTION
When using Polr with the API only, there is no way to increment the click counter on a link. 
I have added an API parameter that allows you to tell polr to increment the click counter on a short url when retrieving via the API.
Issue: #380 