### PR TITLE
Add `mypolr` to "unofficial libraries"

### DIFF
--- a/docs/developer-guide/libraries.md
+++ b/docs/developer-guide/libraries.md
@@ -5,14 +5,6 @@ To interact with Polr's API, you may opt to use a library or write your own inte
 As not all languages and frameworks are currently supported by a library, it is encouraged
 that you take a look at the [API documentation](api/) to integrate Polr into your application.
 
-### Official Libraries
-- there are no official libraries for Polr 2.0 yet.
-
-### Unofficial libraries
-- [mypolr][mypolr_gh] is a Python 3 package for interacting with the Polr 2.0 API. ([User Guide and documentation][mypolr_docs])
-
-- there seems to be only one unofficial libraries for Polr 2.0 yet.
-- perhaps you'd like to write one? Send a PR to add your library to this page.
-
-[mypolr_gh]: https://github.com/fauskanger/mypolr
-[mypolr_docs]: https://mypolr.readthedocs.io
+## Unofficial libraries
+### Python
+- [mypolr](https://github.com/fauskanger/mypolr) is a Python 3 package for interacting with the Polr 2.0 API. ([Documentation](https://mypolr.readthedocs.io))

--- a/docs/developer-guide/libraries.md
+++ b/docs/developer-guide/libraries.md
@@ -9,5 +9,10 @@ that you take a look at the [API documentation](api/) to integrate Polr into you
 - there are no official libraries for Polr 2.0 yet.
 
 ### Unofficial libraries
-- there are no unofficial libraries for Polr 2.0 yet.
+- [mypolr][mypolr_gh] is a Python 3 package for interacting with the Polr 2.0 API. ([User Guide and documentation][mypolr_docs])
+
+- there seems to be only one unofficial libraries for Polr 2.0 yet.
 - perhaps you'd like to write one? Send a PR to add your library to this page.
+
+[mypolr_gh]: https://github.com/fauskanger/mypolr
+[mypolr_docs]: https://mypolr.readthedocs.io


### PR DESCRIPTION
I've added my project `mypolr` ( https://github.com/fauskanger/mypolr ) to the list of unofficial libraries, but not sure if the formatting, wording, or description is on par with what you're looking for.

I also discovered this Ruby project while searching for "Polr" on GitHub, but I haven't checked it out: https://github.com/SeniorMedia/polr-ruby 

It does, however, seem to be stable.