### PR TITLE
Make link placeholder a value

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -9,7 +9,7 @@
 
 <form method='POST' action='/shorten' role='form'>
     <input type='url' autocomplete='off'
-        class='form-control long-link-input' placeholder='http://' name='link-url' />
+        class='form-control long-link-input' placeholder='http://' value='http://' name='link-url' />
 
     <div class='row' id='options' ng-cloak>
         <p>Customize link</p>


### PR DESCRIPTION
Little change to make "http://" as a value in link input field, because browsers block sending the <form> when the value doesn't begin with protocol specification.