### PR TITLE
Add a Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.dockerignore
+.git
+.github
+.idea
+docs/
+tests/
+util/
+.gitignore
+.jshintrc
+.travis.yml
+Dockerfile
+mkdocs.yml
+phpunit.xml
+README.md
+server.php

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,75 @@
+# This Dockerfile uses multi-stage builds to keep the number of layers down.
+# This feature requires Docker version 17.05 or higher.
+
+# ------------------------------------------------------------------------------
+# First build stage: Load Polr dependencies.
+
+FROM php:7.2-apache as build
+
+RUN apt-get update && apt-get install -y --no-install-recommends git unzip
+
+# Install Composer (https://getcomposer.org/doc/faqs/how-to-install-composer-programmatically.md)
+RUN EXPECTED_SIGNATURE="$(curl -sS https://composer.github.io/installer.sig)"; \
+    php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"; \
+    ACTUAL_SIGNATURE="$(php -r "echo hash_file('SHA384', 'composer-setup.php');")"; \
+    if [ "$EXPECTED_SIGNATURE" != "$ACTUAL_SIGNATURE" ]; then \
+        >&2 echo 'ERROR: Invalid installer signature'; \
+        rm composer-setup.php; \
+        exit 1; \
+    fi; \
+    php composer-setup.php --quiet --install-dir=/usr/local/bin --filename=composer; \
+    RESULT=$?; \
+    rm composer-setup.php; \
+    exit $RESULT
+
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+# Run composer before copying remaining project files to leverage caching
+COPY ./composer.* /polr/
+WORKDIR /polr
+RUN composer install --prefer-dist --no-dev --no-autoloader
+
+# Copy project files and re-run composer to finish installation
+COPY ./ /polr/
+RUN composer install --no-dev --optimize-autoloader
+
+# Use default .env file, values are be overridden by environment variables
+RUN mv ./.env.setup ./.env
+
+RUN php artisan geoip:update
+
+# Cleanup
+RUN rm composer.* && rm -rf deploy
+
+
+# ------------------------------------------------------------------------------
+# Second build stage: Startover and use the Polr files created in first stage
+
+FROM php:7.2-apache
+
+LABEL maintainer="The Polr Community, https://polrproject.org/"
+LABEL description="Polr URL Shortener"
+
+# Configure Apache and PHP
+ENV APACHE_DOCUMENT_ROOT /var/lib/www/public
+ENV APACHE_SERVER_NAME localhost
+
+RUN docker-php-ext-install pdo_mysql && \
+    a2enmod rewrite && \
+    sed -ri -e "s!/var/www/html!${APACHE_DOCUMENT_ROOT}!g" /etc/apache2/sites-available/*.conf && \
+    sed -ri -e "s!/var/www/!${APACHE_DOCUMENT_ROOT}!g" /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf && \
+    echo "ServerTokens Prod\n" >> /etc/apache2/apache2.conf && \
+    echo "ServerSignature Off\n" >> /etc/apache2/apache2.conf && \
+    echo "ServerName ${APACHE_SERVER_NAME}" >> /etc/apache2/apache2.conf && \
+    mv ${PHP_INI_DIR}/php.ini-production ${PHP_INI_DIR}/php.ini
+
+# Fetch Polr files from first stage
+COPY --from=build --chown=www-data:www-data /polr ${APACHE_DOCUMENT_ROOT}/../
+
+# Improve performance by setting AllowOverride None
+RUN echo "<Directory ${APACHE_DOCUMENT_ROOT}>" > /etc/apache2/sites-enabled/polr.conf && \
+    echo "AllowOverride None" >> /etc/apache2/sites-enabled/polr.conf && \
+    echo "Options -Indexes +FollowSymLinks" >> /etc/apache2/sites-enabled/polr.conf && \
+    cat ${APACHE_DOCUMENT_ROOT}/.htaccess >> /etc/apache2/sites-enabled/polr.conf && \
+    echo "</directory>" >> /etc/apache2/sites-enabled/polr.conf && \
+    rm ${APACHE_DOCUMENT_ROOT}/.htaccess


### PR DESCRIPTION
This is my take on adding a Dockerfile to Polr.
There are already [other](https://github.com/cydrobolt/polr/pull/339) [approaches](https://github.com/cydrobolt/polr/pull/467) and I would like to add one more to the discussion.

In this solution I am using [an official and community maintained PHP base image](https://hub.docker.com/_/php/) instead of installing everything from scratch. While one could manage to build a smaller image and nginx [is said to be](https://www.eschrade.com/page/why-is-fastcgi-w-nginx-so-much-faster-than-apache-w-mod_php/) more performant than apache, I'd opt for the KISS solution that is easy to maintain and leave all special setups to the individual administrator.

Features:
* [Multi-stage build](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#use-multi-stage-builds) to avoid creating loads of layers.
* Best effort to order everyting in a way that [docker build caching](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#leverage-build-cache) helps reducing build time even when Polr source files have changed.
* `AllowOverride None` is set and the `.htaccess` file gets integrated into the apache configuration [to increase performance](https://httpd.apache.org/docs/2.4/misc/perf-tuning.html#htaccess).
* Most other values are left as is and can get adapted easily to personal needs by mounting custom configuration files into apache's or php's configuration folders.

I am happy for suggestions to improve the code. Some documentation should be added before a possible merge. I'd just like to discuss this way of solving the task before putting more time into it.