### PR TITLE
Make the Advanced Analytics compatible with Cloudflare

### DIFF
--- a/app/Helpers/ClickHelper.php
+++ b/app/Helpers/ClickHelper.php
@@ -5,10 +5,6 @@ use App\Models\Link;
 use Illuminate\Http\Request;
 
 class ClickHelper {
-    static private function getCountry($ip) {
-        $country_iso = geoip()->getLocation($ip)->iso_code;
-        return $country_iso;
-    }
 
     static private function getHost($url) {
         // Return host given URL; NULL if host is
@@ -23,13 +19,13 @@ class ClickHelper {
          * @return boolean
          */
 
-        $ip = $request->ip();
+        $location = geoip()->getLocation(); // Withour the IP specified, it will be detected automatically and use the real user IP if website is behind CloudFlare
         $referer = $request->server('HTTP_REFERER');
 
         $click = new Click;
         $click->link_id = $link->id;
-        $click->ip = $ip;
-        $click->country = self::getCountry($ip);
+        $click->ip = $location->ip;
+        $click->country = $location->iso_code;
         $click->referer = $referer;
         $click->referer_host = ClickHelper::getHost($referer);
         $click->user_agent = $request->server('HTTP_USER_AGENT');


### PR DESCRIPTION
With the previous code, the Geoip service was using the Request IP.
In most of the case that works well but if the website is behind CloudFlare, the IP will be the proxy one.

Now it determines user's real IP if behind cloudflare or not. Fixes #499 #491 

Tell me if you think something needs to be ajusted.