### PR TITLE
Add delete link API functionality

### DIFF
--- a/app/Http/Controllers/Api/ApiLinkController.php
+++ b/app/Http/Controllers/Api/ApiLinkController.php
@@ -137,4 +137,19 @@ class ApiLinkController extends ApiController {
             throw new ApiException('NOT_FOUND', 'Link not found.', 404, $response_type);
         }
     }
+
+    public function deleteLink(Request $request) {
+
+        $response_type = $request->input('response_type');
+        $url_ending = $request->input('url_ending');
+        $link = LinkHelper::linkExists($url_ending);
+
+        if (!$link) {
+            throw new ApiException('DELETION ERROR','The Short Link to delete was not found', 404, $response_type);
+        }
+
+        $link->delete();
+        return "OK";
+    }
+
 }

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -75,4 +75,7 @@ $app->group(['prefix' => '/api/v2', 'namespace' => 'App\Http\Controllers\Api', '
     /* API data endpoints */
     $app->get('data/link', ['as' => 'api_link_analytics', 'uses' => 'ApiAnalyticsController@lookupLinkStats']);
     $app->post('data/link', ['as' => 'api_link_analytics', 'uses' => 'ApiAnalyticsController@lookupLinkStats']);
+
+    /*API delete endpoints */
+    $app->get('admin/delete_link', ['as' => 'api_delete_link', 'uses' => 'ApiLinkController@deleteLink']);
 });

--- a/docs/developer-guide/api.md
+++ b/docs/developer-guide/api.md
@@ -231,6 +231,20 @@ Response:
 }
 ```
 
+### /api/v2/admin/delete_link
+Arguments:
+
+ - `url_ending`: the link ending for the URL to delete. (e.g `5ga`)
+
+An API key granted to a regular user can only be used to delete their own links.
+Admins can delete any link.
+
+Response: An OK if the link was deleted, unauthorised if not authorised to delete or 404 if the link does not exist.
+
+Example: GET `http://example.com/api/v2/admin/delete_link?key=API_KEY_HERE&url_ending=5gk`
+
+Response: `OK`
+
 ## HTTP Error Codes
 The API will return an error code if your request was malformed or another error occured while processing your request.
 


### PR DESCRIPTION
Adds the functionality to be able to delete links to the API. Use documented in the api docs

Closes #592 