### PR TITLE
Fixing performance issue when having millions of links

### DIFF
--- a/app/Helpers/LinkHelper.php
+++ b/app/Helpers/LinkHelper.php
@@ -118,9 +118,12 @@ class LinkHelper {
          */
         $base = env('POLR_BASE');
 
-        $link = Link::where('is_custom', 0)
+        /*$link = Link::where('is_custom', 0)
             ->orderBy('created_at', 'desc')
-            ->first();
+            ->first();*/
+
+        // This change works quite faster after an index creation on is_custom
+        $link = Link::whereRaw('id = (SELECT max(id) FROM links WHERE is_custom = 0)')->get()->first();
 
         if ($link == null) {
             $base10_val = 0;

--- a/database/migrations/2023_06_26_104720_add_link_table_index_on_is_custom.php
+++ b/database/migrations/2023_06_26_104720_add_link_table_index_on_is_custom.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddLinkTableIndexOnIsCustom extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('links', function (Blueprint $table)
+        {
+            // This index helps to find quickly the last ending generated
+            $table->index('is_custom', 'links_is_custom_index');
+        });
+
+    }
+
+    public function down()
+    {
+        Schema::table('links', function (Blueprint $table)
+        {
+            $table->dropIndex('is_custom');
+        });
+    }
+}


### PR DESCRIPTION
Problem emerged when I had more than 1.4 million links generated.
The way the ORM used to find the last ending generated were very inefficient, so I fixed the code, as well included an index that helps to execute the query in less than a millisecond (even having right now more than 13 million links generated).
